### PR TITLE
fix(php-cs-fixer): update rules

### DIFF
--- a/templates/php/php-cs-fixer.php.dotfile
+++ b/templates/php/php-cs-fixer.php.dotfile
@@ -13,10 +13,13 @@ $finder = Symfony\Component\Finder\Finder::create()
     ->ignoreVCS(true);
 
 return (new PhpCsFixer\Config())
+    ->setRiskyAllowed(true)
     ->setRules([
         '@PSR12' => true,
         '@PHP82Migration' => true,
         '@PhpCsFixer:risky' => true,
+        'declare_strict_types' => true,
+        'single_quote' => true,
         'multiline_whitespace_before_semicolons' => ['strategy' => 'no_multi_line'],
         'comment_to_phpdoc' => false,
         'is_null' => false,
@@ -51,6 +54,7 @@ return (new PhpCsFixer\Config())
         'class_attributes_separation' => [
             'elements' => [
                 'method' => 'one',
+                'trait_import' => 'none',
             ],
         ],
         'method_argument_space' => [
@@ -81,7 +85,6 @@ return (new PhpCsFixer\Config())
                 'switch',
                 'throw',
                 'use',
-                'use_trait',
             ],
         ],
         'native_constant_invocation' => [


### PR DESCRIPTION
- `use_trait` in `no_extra_blank_lines` is deprecated and moved to `class_attributes_separation`
- `->setRiskyAllowed(true)` is needed for PHPStorm to allow running this config