### PR TITLE
fix(eslint): ignore storage folder

### DIFF
--- a/templates/eslint/eslintignore.dotfile
+++ b/templates/eslint/eslintignore.dotfile
@@ -1,4 +1,5 @@
 node_modules
 public
+storage
 vendor
 **/dist


### PR DESCRIPTION
Ignore the storage folder, otherwise you for example get errors on the json files of Clockwork.