### PR TITLE
fix(eslint): ignore tests folder 

### DIFF
--- a/templates/eslint/eslintignore.dotfile
+++ b/templates/eslint/eslintignore.dotfile
@@ -1,4 +1,5 @@
 node_modules
 public
+storage
 vendor
 **/dist

--- a/templates/eslint/eslintignore.dotfile
+++ b/templates/eslint/eslintignore.dotfile
@@ -2,5 +2,6 @@ node_modules
 public
 storage
 resources/i18n/*.json
+tests
 vendor
 **/dist

--- a/templates/eslint/eslintignore.dotfile
+++ b/templates/eslint/eslintignore.dotfile
@@ -1,5 +1,6 @@
 node_modules
 public
 storage
+resources/i18n/*.json
 vendor
 **/dist


### PR DESCRIPTION
Im having some JSON fixtures in my test folder, to test external API calls.
JSON linting throws errors on them.